### PR TITLE
Fixed link to in Helm setup doc

### DIFF
--- a/site/helm-get-started.md
+++ b/site/helm-get-started.md
@@ -182,4 +182,4 @@ very straight-forward and are a quite natural work-flow.
 # Next
 
 As a next step, you might want to dive deeper into [how to control
-Flux](../using.md).
+Flux](./using.md).


### PR DESCRIPTION
The link was previously broken, looks like it was copied in from the standalone doc (which is under site directory)